### PR TITLE
Metrics/TPS pipeline: code-review fixes + TPS unit tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -173,13 +173,20 @@ app.get('/health/dependencies', async (req, res) => {
     if (!url) return { name, status: 'unconfigured' };
     const startedAt = Date.now();
     try {
-      await axios.get(url, {
+      const response = await axios.get(url, {
         timeout: 5000,
-        // Any HTTP response means the host is reachable; we only care about
-        // connectivity here, not the specific status code.
+        // Resolve on any status so we can classify it ourselves below rather
+        // than treating a 5xx as a thrown error.
         validateStatus: () => true
       });
-      return { name, status: 'reachable', latencyMs: Date.now() - startedAt };
+      const latencyMs = Date.now() - startedAt;
+      // A 5xx means the upstream is reachable but degraded/erroring — exactly the
+      // condition that breaks the cron metric updates — so report it as degraded.
+      // A <500 response (incl. a 404 on the API root) just means it's serving.
+      if (response.status >= 500) {
+        return { name, status: 'degraded', httpStatus: response.status, latencyMs };
+      }
+      return { name, status: 'reachable', httpStatus: response.status, latencyMs };
     } catch (error) {
       return { name, status: 'unreachable', error: error.message };
     }
@@ -251,21 +258,23 @@ const initializeDataUpdates = async () => {
             }
           }
 
-          // Fetch TPS and metrics if evmChainId is available
+          // Fetch metrics if evmChainId is available
           const chainIdForTps = dbChain.evmChainId;
           if (chainIdForTps && /^\d+$/.test(String(chainIdForTps))) {
-            logger.debug(`[METRICS] Fetching metrics for ${dbChain.chainName} (evmChainId: ${chainIdForTps})`);
+            const id = String(chainIdForTps);
+            logger.debug(`[METRICS] Fetching metrics for ${dbChain.chainName} (evmChainId: ${id})`);
 
-            // Add initial TPS update
-            await tpsService.updateTpsData(String(chainIdForTps));
-            // Add initial Transaction Count update
-            await tpsService.updateCumulativeTxCount(String(chainIdForTps));
-            // Add initial Gas Used update
-            await gasUsedService.updateGasUsedData(String(chainIdForTps));
-            // Add initial Average Gas Price update
-            await avgGasPriceService.updateAvgGasPriceData(String(chainIdForTps));
-            // Add initial Fees Paid update
-            await feesPaidService.updateFeesPaidData(String(chainIdForTps));
+            // Independent fetches run concurrently. Daily txCount is included
+            // because TPS is derived from it (no separate TPS fetch).
+            await Promise.all([
+              tpsService.updateCumulativeTxCount(id),
+              txCountService.updateTxCountData(id),
+              gasUsedService.updateGasUsedData(id),
+              avgGasPriceService.updateAvgGasPriceData(id),
+              feesPaidService.updateFeesPaidData(id)
+            ]);
+            // Derive TPS from the daily txCount fetched just above.
+            await tpsService.updateTpsData(id);
 
             logger.info(`[INIT] Completed all metrics for ${dbChain.chainName}`);
           } else {
@@ -375,25 +384,37 @@ const initializeDataUpdates = async () => {
               }
             }
 
-            // Fetch TPS and metrics if evmChainId is available
+            // Update all metrics if evmChainId is available
             const chainIdForTps = dbChain.evmChainId;
             if (chainIdForTps && /^\d+$/.test(String(chainIdForTps))) {
-              // Add TPS update for each chain
-              await tpsService.updateTpsData(String(chainIdForTps));
-              // Add Max TPS update for each chain
-              await maxTpsService.updateMaxTpsData(String(chainIdForTps));
-              // Add Cumulative Transaction Count update for each chain
-              await tpsService.updateCumulativeTxCount(String(chainIdForTps));
-              // Add Daily Transaction Count update for each chain
-              await txCountService.updateTxCountData(String(chainIdForTps));
-              // Add Active Addresses update for each chain
-              await activeAddressesService.updateActiveAddressesData(String(chainIdForTps));
-              // Add Gas Used update for each chain
-              await gasUsedService.updateGasUsedData(String(chainIdForTps));
-              // Add Average Gas Price update for each chain
-              await avgGasPriceService.updateAvgGasPriceData(String(chainIdForTps));
-              // Add Fees Paid update for each chain
-              await feesPaidService.updateFeesPaidData(String(chainIdForTps));
+              const id = String(chainIdForTps);
+
+              // These metrics each fetch independently and own a separate rate
+              // limit budget, so run them concurrently rather than one-by-one.
+              const metricResults = await Promise.all([
+                maxTpsService.updateMaxTpsData(id),
+                tpsService.updateCumulativeTxCount(id),
+                txCountService.updateTxCountData(id),
+                activeAddressesService.updateActiveAddressesData(id),
+                gasUsedService.updateGasUsedData(id),
+                avgGasPriceService.updateAvgGasPriceData(id),
+                feesPaidService.updateFeesPaidData(id)
+              ]);
+
+              // TPS is derived from the daily txCount fetched just above, so it
+              // runs after txCountService has stored it (no extra API call).
+              const tpsResult = await tpsService.updateTpsData(id);
+
+              // Surface metric-level failures instead of always reporting
+              // success: the metric services return { success: false } (they do
+              // not throw) when every retry fails.
+              const failed = [...metricResults, tpsResult].filter(r => r && r.success === false);
+              if (failed.length > 0) {
+                logger.warn(`[CRON] ${dbChain.chainName}: ${failed.length} of 8 metric updates failed`, {
+                  errors: failed.map(r => r.error).filter(Boolean)
+                });
+                return { success: false, chain: dbChain.chainName, failedMetrics: failed.length };
+              }
             }
 
             logger.info(`[CRON] Successfully updated ${dbChain.chainName}`);

--- a/src/services/tpsService.js
+++ b/src/services/tpsService.js
@@ -1,246 +1,129 @@
 const TPS = require('../models/tps');
 const CumulativeTxCount = require('../models/cumulativeTxCount');
-const axios = require('axios');
+const TxCount = require('../models/txCount');
 const Chain = require('../models/chain');
 const config = require('../config/config');
 const logger = require('../utils/logger');
+const createMetricService = require('./metricService');
 
-// Rate limiter implementation
-class RateLimiter {
-  constructor(maxRequestsPerMinute = 30) {
-    this.queue = [];
-    this.processing = false;
-    this.maxRequestsPerMinute = maxRequestsPerMinute;
-    this.requestTimestamps = [];
-  }
+// Cumulative transaction count is a plain day-bucketed metric, so it reuses the
+// shared metric factory (fetch + rate-limit + retry + upsert) like every other
+// metric service. TPS itself is NOT fetched from the API: it is derived below
+// from the daily `txCount` that txCountService already stores, avoiding a second
+// identical request to /metrics/txCount per chain.
+const cumulativeTxCountService = createMetricService({
+  model: CumulativeTxCount,
+  metricPath: 'cumulativeTxCount',
+  label: 'Cumulative TxCount',
+  aggregation: 'sum'
+});
 
-  // Add a request to the queue
-  async enqueue(fn) {
-    return new Promise((resolve, reject) => {
-      this.queue.push({ fn, resolve, reject });
-      this.processQueue();
-    });
-  }
-
-  // Process the queue
-  async processQueue() {
-    if (this.processing || this.queue.length === 0) return;
-    
-    this.processing = true;
-    
-    try {
-      // Check if we've exceeded rate limit
-      const now = Date.now();
-      this.requestTimestamps = this.requestTimestamps.filter(
-        timestamp => now - timestamp < 60000 // Keep only timestamps from the last minute
-      );
-      
-      if (this.requestTimestamps.length >= this.maxRequestsPerMinute) {
-        // We've hit the rate limit, wait until we can make another request
-        const oldestTimestamp = this.requestTimestamps[0];
-        const timeToWait = 60000 - (now - oldestTimestamp);
-        
-        logger.info(`Rate limit reached, waiting ${Math.round(timeToWait/1000)}s before next request`);
-        
-        setTimeout(() => {
-          this.processing = false;
-          this.processQueue();
-        }, timeToWait + 100); // Add a small buffer
-        
-        return;
-      }
-      
-      // Process the next item in the queue
-      const item = this.queue.shift();
-      this.requestTimestamps.push(now);
-      
-      try {
-        const result = await item.fn();
-        item.resolve(result);
-      } catch (error) {
-        item.reject(error);
-      }
-      
-      // Small delay between requests
-      setTimeout(() => {
-        this.processing = false;
-        this.processQueue();
-      }, 300); // 300ms between requests
-    } catch (error) {
-      logger.error('Error in rate limiter:', error);
-      this.processing = false;
-    }
-  }
-}
-
-// Create a global rate limiter instance
-const metricsApiRateLimiter = new RateLimiter(config.api.metrics.rateLimit.requestsPerMinute || 20);
+// The in-progress (current UTC day) txCount bucket only covers the seconds
+// elapsed so far. Dividing by a tiny window produces wildly inflated or (at
+// exactly midnight) zero TPS, so the elapsed-seconds denominator is floored to
+// this value. Past days always span a full 86400s window, so the floor never
+// affects them — it only damps the in-progress day's first hour.
+const MIN_ELAPSED_SECONDS = 60 * 60; // 1 hour
+const FULL_DAY_SECONDS = 24 * 60 * 60;
 
 class TpsService {
-  async updateTpsData(chainId, retryCount = config.api.metrics.rateLimit.maxRetries || 3, initialBackoffMs = config.api.metrics.rateLimit.retryDelay || 2000) {
-    // Use rate limiter for all API calls
-    return metricsApiRateLimiter.enqueue(async () => {
-      for (let attempt = 1; attempt <= retryCount; attempt++) {
-        try {
-          logger.info(`[TPS Update] Starting update for chain ${chainId} (Attempt ${attempt}/${retryCount})`);
-          
-          // Use the new metrics API endpoint
-          const headers = {
-            'Accept': 'application/json',
-            'User-Agent': 'l1beat-backend',
-            'Cache-Control': 'no-cache' // Avoid cached responses
-          };
+  /**
+   * Derives decimal TPS from the daily txCount already fetched by txCountService
+   * and stores it in the TPS collection. Makes no external API call.
+   *
+   * For a completed day TPS = txCount / 86400 (matching the metrics API's
+   * integer avgTps but with decimal precision). For the in-progress day TPS =
+   * txCountSoFar / secondsElapsedSoFar, but only once MIN_ELAPSED_SECONDS have
+   * passed so the value isn't divided by a tiny (or zero) denominator.
+   *
+   * @param {string} chainId - The chain ID
+   * @returns {Promise<Object>} - Result with { success, chainId, recordsProcessed }
+   */
+  async updateTpsData(chainId) {
+    try {
+      const currentTime = Math.floor(Date.now() / 1000);
+      const thirtyDaysAgo = currentTime - (30 * 24 * 60 * 60);
 
-          // Add API key if available
-          if (process.env.GLACIER_API_KEY) {
-            headers['x-api-key'] = process.env.GLACIER_API_KEY;
-          }
+      const txCountRecords = await TxCount.find({
+        chainId: String(chainId),
+        timestamp: { $gte: thirtyDaysAgo, $lte: currentTime }
+      })
+        .select('timestamp value')
+        .lean();
 
-          // The metrics API's `avgTps` metric is rounded to whole integers. To get
-          // decimal precision we instead fetch the daily `txCount` and derive TPS
-          // ourselves as txCount / secondsElapsedInBucket (see bulkWrite below).
-          const response = await axios.get(`${config.api.metrics.baseUrl}/chains/${chainId}/metrics/txCount`, {
-            params: {
-              timeInterval: 'day',
-              pageSize: 100  // Maximum allowed by API
-            },
-            timeout: config.api.metrics.timeout,
-            headers
-          });
-
-          // Enhanced error logging
-          if (!response.data) {
-            logger.warn(`[TPS Update] No data in response for chain ${chainId}`);
-            continue;
-          }
-
-          if (!Array.isArray(response.data.results)) {
-            logger.warn(`[TPS Update] Invalid response format for chain ${chainId}:`, response.data);
-            continue;
-          }
-
-          const currentTime = Math.floor(Date.now() / 1000);
-          const thirtyDaysAgo = currentTime - (30 * 24 * 60 * 60);
-
-          // Log raw data before filtering
-          logger.info(`[TPS Update] Raw data for chain ${chainId}:`, {
-            resultsCount: response.data.results.length,
-            sampleData: response.data.results[0],
-            environment: process.env.NODE_ENV
-          });
-
-          // Validate and filter TPS data
-          const validTpsData = response.data.results.filter(item => {
-            const timestamp = Number(item.timestamp);
-            const value = parseFloat(item.value);
-            
-            if (isNaN(timestamp) || isNaN(value)) {
-              logger.warn(`[TPS Update] Invalid data point for chain ${chainId}:`, item);
-              return false;
-            }
-            
-            const isValid = timestamp >= thirtyDaysAgo && timestamp <= currentTime;
-            if (!isValid) {
-              logger.debug(`[TPS Update] Out of range timestamp for chain ${chainId}:`, {
-                timestamp: new Date(timestamp * 1000).toISOString(),
-                value
-              });
-            }
-            
-            return isValid;
-          });
-
-          // If we have valid data, proceed with update
-          if (validTpsData.length > 0) {
-            const result = await TPS.bulkWrite(
-              validTpsData.map(item => {
-                const timestamp = Number(item.timestamp);
-                // `timestamp` marks the start of the day-bucket; `value` is the tx
-                // count within it. Past buckets cover a full day (86400s); the
-                // in-progress bucket only covers the seconds elapsed so far. Dividing
-                // by elapsed seconds yields decimal TPS matching the API's avgTps.
-                const elapsedSeconds = Math.min(86400, currentTime - timestamp);
-                const tps = elapsedSeconds > 0 ? parseFloat(item.value) / elapsedSeconds : 0;
-                return {
-                  updateOne: {
-                    filter: {
-                      chainId: chainId,
-                      timestamp: timestamp
-                    },
-                    update: {
-                      $set: {
-                        value: parseFloat(tps.toFixed(2)),
-                        lastUpdated: new Date()
-                      }
-                    },
-                    upsert: true
-                  }
-                };
-              }),
-              { ordered: false } // Continue processing even if some operations fail
-            );
-
-            logger.info(`[TPS Update] Success for chain ${chainId}:`, {
-              validDataPoints: validTpsData.length,
-              matched: result.matchedCount,
-              modified: result.modifiedCount,
-              upserted: result.upsertedCount,
-              environment: process.env.NODE_ENV
-            });
-
-            return result;
-          }
-
-          logger.warn(`[TPS Update] No valid data points for chain ${chainId}`);
-          return null;
-
-        } catch (error) {
-          const status = error.response?.status;
-          logger.error(`[TPS Update] Error for chain ${chainId} (Attempt ${attempt}/${retryCount}):`, {
-            message: error.message,
-            status: status,
-            data: error.response?.data,
-            stack: process.env.NODE_ENV === 'development' ? error.stack : undefined
-          });
-
-          // Special handling for rate limiting
-          if (status === 429) {
-            logger.warn(`[TPS Update] Rate limit exceeded for metrics API, backing off...`);
-            
-            if (attempt < retryCount) {
-              // Exponential backoff with jitter for rate limit errors
-              const backoffTime = initialBackoffMs * Math.pow(2, attempt - 1) * (0.75 + Math.random() * 0.5);
-              logger.info(`[TPS Update] Will retry after ${Math.round(backoffTime/1000)}s`);
-              await new Promise(resolve => setTimeout(resolve, backoffTime));
-            }
-          } else if (attempt < retryCount) {
-            // Normal retry for other errors, with shorter backoff
-            const backoffTime = initialBackoffMs * (attempt - 1) * (0.75 + Math.random() * 0.5);
-            await new Promise(resolve => setTimeout(resolve, backoffTime));
-          }
-
-          if (attempt === retryCount) {
-            // On final attempt, log but don't throw
-            logger.error(`[TPS Update] All attempts failed for chain ${chainId}`);
-            return null;
-          }
-        }
+      if (txCountRecords.length === 0) {
+        logger.info(`[TPS Update] No txCount data to derive TPS from for chain ${chainId}`);
+        return { success: true, chainId, recordsProcessed: 0, message: 'No txCount data available' };
       }
-      return null;
-    });
+
+      const ops = [];
+      for (const record of txCountRecords) {
+        const timestamp = Number(record.timestamp);
+        const value = parseFloat(record.value);
+
+        if (isNaN(timestamp) || isNaN(value)) {
+          continue;
+        }
+
+        // `timestamp` marks the start of the day-bucket. Past buckets cover a
+        // full day (86400s); the in-progress bucket covers the seconds elapsed
+        // so far. Skip non-positive windows (e.g. a future timestamp from clock
+        // skew) and floor the denominator so the in-progress day's first hour
+        // isn't divided by a tiny window (which would spike TPS).
+        const elapsedSeconds = Math.min(FULL_DAY_SECONDS, currentTime - timestamp);
+        if (elapsedSeconds <= 0) {
+          continue;
+        }
+
+        const denominator = Math.max(elapsedSeconds, MIN_ELAPSED_SECONDS);
+        const tps = parseFloat((value / denominator).toFixed(2));
+        ops.push({
+          updateOne: {
+            filter: { chainId: String(chainId), timestamp },
+            update: { $set: { value: tps, lastUpdated: new Date() } },
+            upsert: true
+          }
+        });
+      }
+
+      if (ops.length === 0) {
+        logger.info(`[TPS Update] No eligible txCount buckets to derive TPS for chain ${chainId}`);
+        return { success: true, chainId, recordsProcessed: 0, message: 'No eligible data points' };
+      }
+
+      const result = await TPS.bulkWrite(ops, { ordered: false });
+
+      logger.info(`[TPS Update] Derived TPS for chain ${chainId}:`, {
+        recordsProcessed: ops.length,
+        upserted: result.upsertedCount,
+        modified: result.modifiedCount,
+        environment: process.env.NODE_ENV
+      });
+
+      return {
+        success: true,
+        chainId,
+        recordsProcessed: ops.length,
+        upserted: result.upsertedCount,
+        modified: result.modifiedCount
+      };
+    } catch (error) {
+      logger.error(`[TPS Update] Error deriving TPS for chain ${chainId}:`, error.message);
+      return { success: false, chainId, error: error.message };
+    }
   }
 
   async getTpsHistory(chainId, days = 30) {
     try {
       const existingData = await TPS.countDocuments({ chainId });
-      
+
       if (existingData === 0) {
-        logger.info(`No TPS history found for chain ${chainId}, fetching from API...`);
+        logger.info(`No TPS history found for chain ${chainId}, deriving from txCount...`);
         await this.updateTpsData(chainId);
       }
 
       const cutoffDate = Math.floor(Date.now() / 1000) - (days * 24 * 60 * 60);
-      
+
       const data = await TPS.find({
         chainId,
         timestamp: { $gte: cutoffDate }
@@ -248,7 +131,7 @@ class TpsService {
         .sort({ timestamp: -1 })
         .select('-_id timestamp value')
         .lean();
-      
+
       logger.info(`Found ${data.length} TPS records for chain ${chainId}`);
       return data;
     } catch (error) {
@@ -319,18 +202,18 @@ class TpsService {
       const tpsResults = await Promise.all(latestTpsPromises);
       const validResults = tpsResults.filter(result => {
         if (!result) return false;
-        
+
         // Validate the timestamp is reasonable
         const timestamp = result.timestamp;
         const isValid = timestamp >= oneDayAgo && timestamp <= currentTime;
-        
+
         if (!isValid) {
           logger.warn(`Invalid timestamp for chain ${result.chainId}:`, {
             timestamp: new Date(timestamp * 1000).toISOString(),
             value: result.value
           });
         }
-        
+
         return isValid;
       });
 
@@ -454,144 +337,14 @@ class TpsService {
   }
 
   /**
-   * Updates cumulative transaction count data for a specific chain
+   * Updates cumulative transaction count data for a specific chain via the shared
+   * metric factory.
    * @param {string} chainId - The chain ID
    * @param {number} retryCount - Number of retry attempts
-   * @param {number} initialBackoffMs - Initial backoff time in milliseconds
-   * @returns {Promise<Object|null>} - The result of the update operation or null on failure
+   * @returns {Promise<Object>} - The result of the update operation
    */
-  async updateCumulativeTxCount(chainId, retryCount = config.api.metrics.rateLimit.maxRetries || 3, initialBackoffMs = config.api.metrics.rateLimit.retryDelay || 2000) {
-    // Use rate limiter for all API calls
-    return metricsApiRateLimiter.enqueue(async () => {
-      for (let attempt = 1; attempt <= retryCount; attempt++) {
-        try {
-          logger.info(`[TxCount Update] Starting update for chain ${chainId} (Attempt ${attempt}/${retryCount})`);
-          
-          // Use the metrics API endpoint with cumulativeTxCount metric (daily interval)
-          const response = await axios.get(`${config.api.metrics.baseUrl}/chains/${chainId}/metrics/cumulativeTxCount`, {
-            params: {
-              timeInterval: 'day',
-              pageSize: 100  // Maximum allowed by API
-            },
-            timeout: config.api.metrics.timeout,
-            headers: {
-              'Accept': 'application/json',
-              'User-Agent': 'l1beat-backend',
-              'Cache-Control': 'no-cache' // Avoid cached responses
-            }
-          });
-
-          // Enhanced error logging
-          if (!response.data) {
-            logger.warn(`[TxCount Update] No data in response for chain ${chainId}`);
-            continue;
-          }
-
-          if (!Array.isArray(response.data.results)) {
-            logger.warn(`[TxCount Update] Invalid response format for chain ${chainId}:`, response.data);
-            continue;
-          }
-
-          const currentTime = Math.floor(Date.now() / 1000);
-          const thirtyDaysAgo = currentTime - (30 * 24 * 60 * 60);
-
-          // Log raw data before filtering
-          logger.info(`[TxCount Update] Raw data for chain ${chainId}:`, {
-            resultsCount: response.data.results.length,
-            sampleData: response.data.results[0],
-            environment: process.env.NODE_ENV
-          });
-
-          // Validate and filter TxCount data
-          const validTxCountData = response.data.results.filter(item => {
-            const timestamp = Number(item.timestamp);
-            const value = parseFloat(item.value);
-            
-            if (isNaN(timestamp) || isNaN(value)) {
-              logger.warn(`[TxCount Update] Invalid data point for chain ${chainId}:`, item);
-              return false;
-            }
-            
-            const isValid = timestamp >= thirtyDaysAgo && timestamp <= currentTime;
-            if (!isValid) {
-              logger.debug(`[TxCount Update] Out of range timestamp for chain ${chainId}:`, {
-                timestamp: new Date(timestamp * 1000).toISOString(),
-                value
-              });
-            }
-            
-            return isValid;
-          });
-
-          // If we have valid data, proceed with update
-          if (validTxCountData.length > 0) {
-            const result = await CumulativeTxCount.bulkWrite(
-              validTxCountData.map(item => ({
-                updateOne: {
-                  filter: { 
-                    chainId: chainId,
-                    timestamp: Number(item.timestamp)
-                  },
-                  update: { 
-                    $set: { 
-                      value: parseFloat(item.value),
-                      lastUpdated: new Date() 
-                    }
-                  },
-                  upsert: true
-                }
-              })),
-              { ordered: false } // Continue processing even if some operations fail
-            );
-
-            logger.info(`[TxCount Update] Success for chain ${chainId}:`, {
-              validDataPoints: validTxCountData.length,
-              matched: result.matchedCount,
-              modified: result.modifiedCount,
-              upserted: result.upsertedCount,
-              environment: process.env.NODE_ENV
-            });
-
-            return result;
-          }
-
-          logger.warn(`[TxCount Update] No valid data points for chain ${chainId}`);
-          return null;
-
-        } catch (error) {
-          const status = error.response?.status;
-          logger.error(`[TxCount Update] Error for chain ${chainId} (Attempt ${attempt}/${retryCount}):`, {
-            message: error.message,
-            status: status,
-            data: error.response?.data,
-            stack: process.env.NODE_ENV === 'development' ? error.stack : undefined
-          });
-
-          // Special handling for rate limiting
-          if (status === 429) {
-            logger.warn(`[TxCount Update] Rate limit exceeded for metrics API, backing off...`);
-            
-            if (attempt < retryCount) {
-              // Exponential backoff with jitter for rate limit errors
-              const backoffTime = initialBackoffMs * Math.pow(2, attempt - 1) * (0.75 + Math.random() * 0.5);
-              logger.info(`[TxCount Update] Will retry after ${Math.round(backoffTime/1000)}s`);
-              await new Promise(resolve => setTimeout(resolve, backoffTime));
-            }
-          } else if (attempt < retryCount) {
-            // Normal retry for other errors, with shorter backoff
-            const backoffTime = initialBackoffMs * (attempt - 1) * (0.75 + Math.random() * 0.5);
-            await new Promise(resolve => setTimeout(resolve, backoffTime));
-          }
-
-          if (attempt === retryCount) {
-            // On final attempt, log but don't throw
-            logger.error(`[TxCount Update] All attempts failed for chain ${chainId}`);
-            return null;
-          }
-        }
-      }
-      return null;
-    });
+  async updateCumulativeTxCount(chainId, retryCount = config.api.metrics.rateLimit.maxRetries || 3) {
+    return cumulativeTxCountService.updateData(String(chainId), retryCount);
   }
 
   /**
@@ -612,14 +365,14 @@ class TpsService {
       }
 
       const existingData = await CumulativeTxCount.countDocuments({ chainId });
-      
+
       if (existingData === 0) {
         logger.info(`No TxCount history found for chain ${chainId}, fetching from API...`);
-        await this.updateCumulativeTxCount(chainId, config.api.metrics.rateLimit.maxRetries, config.api.metrics.rateLimit.retryDelay);
+        await this.updateCumulativeTxCount(chainId, config.api.metrics.rateLimit.maxRetries);
       }
 
       const cutoffDate = Math.floor(Date.now() / 1000) - (days * 24 * 60 * 60);
-      
+
       const data = await CumulativeTxCount.find({
         chainId,
         timestamp: { $gte: cutoffDate }
@@ -627,12 +380,12 @@ class TpsService {
         .sort({ timestamp: -1 })
         .select('-_id timestamp value')
         .lean();
-      
+
       logger.info(`Found ${data.length} TxCount records for chain ${chainId}`);
-      
+
       // Cache the result for 5 minutes
       cacheManager.set(cacheKey, data, config.cache.txCount);
-      
+
       return data;
     } catch (error) {
       logger.error(`Error fetching TxCount history: ${error.message}`);
@@ -663,18 +416,18 @@ class TpsService {
 
       if (!latest) {
         logger.info(`No TxCount data found for chain ${chainId}, fetching from API...`);
-        await this.updateCumulativeTxCount(chainId, config.api.metrics.rateLimit.maxRetries, config.api.metrics.rateLimit.retryDelay);
+        await this.updateCumulativeTxCount(chainId, config.api.metrics.rateLimit.maxRetries);
         latest = await CumulativeTxCount.findOne({ chainId })
           .sort({ timestamp: -1 })
           .select('-_id timestamp value')
           .lean();
       }
-      
+
       // Cache the result for 5 minutes
       if (latest) {
         cacheManager.set(cacheKey, latest, config.cache.txCount);
       }
-      
+
       return latest;
     } catch (error) {
       logger.error(`Error fetching latest TxCount: ${error.message}`);
@@ -683,4 +436,4 @@ class TpsService {
   }
 }
 
-module.exports = new TpsService(); 
+module.exports = new TpsService();

--- a/src/utils/initWeeklyData.js
+++ b/src/utils/initWeeklyData.js
@@ -46,9 +46,9 @@ async function initWeeklyData() {
       }
     }
 
-    // Start the weekly data update using the new method that fetches all data at once
+    // Start the resumable weekly data update (fetches the 7 day-windows).
     console.log('Starting weekly teleporter data update...');
-    const result = await teleporterService.fetchWeeklyTeleporterDataAtOnce();
+    const result = await teleporterService.updateWeeklyData();
     
     console.log('Weekly data update completed:', {
       success: result.success,

--- a/tests/tpsDerivation.test.js
+++ b/tests/tpsDerivation.test.js
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for TPS derivation in tpsService.updateTpsData.
+ *
+ * TPS is derived from the daily txCount already stored by txCountService (no
+ * API call). These tests pin the derivation math:
+ *   - completed day: tps = txCount / 86400
+ *   - in-progress day: denominator floored to 1h so a tiny window can't spike
+ *   - non-positive window (future timestamp): skipped
+ *   - non-numeric value: skipped
+ *
+ * This file intentionally does NOT require ./setup, which globally mocks
+ * tpsService — here we exercise the real implementation against mocked models.
+ */
+
+jest.mock('../src/models/tps', () => ({ bulkWrite: jest.fn() }));
+jest.mock('../src/models/txCount', () => ({ find: jest.fn() }));
+jest.mock('../src/models/cumulativeTxCount', () => ({}));
+jest.mock('../src/models/chain', () => ({ find: jest.fn() }));
+// cumulativeTxCount delegates to the shared factory; stub it so requiring
+// tpsService doesn't spin up a real metric service.
+jest.mock('../src/services/metricService', () => () => ({
+  updateData: jest.fn(),
+  updateAllChains: jest.fn(),
+  getHistory: jest.fn(),
+  getLatest: jest.fn(),
+  getNetworkHistory: jest.fn(),
+  getNetworkLatest: jest.fn()
+}));
+
+const TPS = require('../src/models/tps');
+const TxCount = require('../src/models/txCount');
+const tpsService = require('../src/services/tpsService');
+
+const NOW_SECONDS = 1_700_000_000;
+const DAY = 24 * 60 * 60;
+
+// Make TxCount.find(...).select(...).lean() resolve to the given rows.
+function stubTxCountRows(rows) {
+  TxCount.find.mockReturnValue({
+    select: () => ({ lean: async () => rows })
+  });
+}
+
+// Capture the ops passed to TPS.bulkWrite and key them by timestamp.
+function captureBulkWrite() {
+  let ops = [];
+  TPS.bulkWrite.mockImplementation(async (received) => {
+    ops = received;
+    return { upsertedCount: received.length, modifiedCount: 0 };
+  });
+  return () => ops.map(op => ({
+    timestamp: op.updateOne.filter.timestamp,
+    value: op.updateOne.update.$set.value
+  }));
+}
+
+describe('tpsService.updateTpsData derivation', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW_SECONDS * 1000);
+  });
+
+  it('derives full-day TPS and floors the in-progress day denominator', async () => {
+    const getWritten = captureBulkWrite();
+    stubTxCountRows([
+      // Completed day: well over 86400s ago → full-day window. 86400/86400 = 1.00
+      { timestamp: NOW_SECONDS - 3 * DAY, value: 86400 },
+      // In-progress day: only 600s elapsed → denominator floored to 3600s.
+      // Without the floor this would spike to 1800/600 = 3.00; with it, 0.50.
+      { timestamp: NOW_SECONDS - 600, value: 1800 }
+    ]);
+
+    const result = await tpsService.updateTpsData('42');
+
+    expect(result.success).toBe(true);
+    expect(result.recordsProcessed).toBe(2);
+
+    const written = getWritten();
+    expect(written).toContainEqual({ timestamp: NOW_SECONDS - 3 * DAY, value: 1 });
+    expect(written).toContainEqual({ timestamp: NOW_SECONDS - 600, value: 0.5 });
+  });
+
+  it('skips future timestamps and non-numeric values', async () => {
+    const getWritten = captureBulkWrite();
+    stubTxCountRows([
+      { timestamp: NOW_SECONDS - 2 * DAY, value: 43200 }, // valid → 0.50
+      { timestamp: NOW_SECONDS + 100, value: 999 },        // future → elapsed <= 0, skip
+      { timestamp: NOW_SECONDS - DAY, value: 'oops' }      // NaN value → skip
+    ]);
+
+    const result = await tpsService.updateTpsData('42');
+
+    expect(result.recordsProcessed).toBe(1);
+    const written = getWritten();
+    expect(written).toEqual([{ timestamp: NOW_SECONDS - 2 * DAY, value: 0.5 }]);
+  });
+
+  it('returns a no-op success result when there is no txCount data', async () => {
+    stubTxCountRows([]);
+
+    const result = await tpsService.updateTpsData('42');
+
+    expect(result).toMatchObject({ success: true, recordsProcessed: 0 });
+    expect(TPS.bulkWrite).not.toHaveBeenCalled();
+  });
+
+  it('returns a failure result (not a throw) when the write fails', async () => {
+    stubTxCountRows([{ timestamp: NOW_SECONDS - 2 * DAY, value: 43200 }]);
+    TPS.bulkWrite.mockRejectedValue(new Error('db down'));
+
+    const result = await tpsService.updateTpsData('42');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/db down/);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the findings from the high-effort code review of the metrics/TPS pipeline, plus unit tests for the new TPS derivation.

### Fixes
- **No duplicate API call:** TPS is now derived from the daily `txCount` already stored by `txCountService` instead of re-fetching `/metrics/txCount` per chain per cron cycle.
- **Shared infra:** `cumulativeTxCount` now uses `createMetricService`; `tpsService` no longer carries its own copy of the `RateLimiter` / fetch-retry loop (~400 lines removed).
- **Intraday TPS:** the elapsed-seconds denominator is floored to 1h, so the in-progress day bucket can't spike on a tiny window or divide by zero at midnight; completed days (full 86400s window) are unaffected.
- **Cron observability:** the per-chain cron now inspects each metric update's `{success}` result and reports the chain as failed instead of always logging success.
- **Concurrency:** independent per-chain metric updates run concurrently; TPS derives after txCount is fetched.
- **Health probe:** `/health/dependencies` now reports a 5xx upstream as `degraded` (503) rather than `reachable`.
- **Stale script:** `initWeeklyData.js` calls `updateWeeklyData()` (the prior method name no longer existed).

### Tests
- New `tests/tpsDerivation.test.js` exercises the real `tpsService.updateTpsData` against mocked models: full-day division, the in-progress denominator floor (spike guard), skipping future/non-numeric rows, the empty no-op result, and the failure-result-not-throw path.

## Testing
- Full suite green: **14 suites, 200 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)